### PR TITLE
Correctly parse the 'B' bytes suffix added by ZoL commit e7fbeb606a

### DIFF
--- a/zfs-snapshot-disk-usage-matrix.py
+++ b/zfs-snapshot-disk-usage-matrix.py
@@ -97,6 +97,8 @@ def size_in_bytes(size):
         return float(size[:-1])*pow(1024.0,3)
     if size.endswith("T"):
         return float(size[:-1])*pow(1024.0,4)
+    if size.endswith("B"):
+        return int(size[:-1])
     return int(size)
     
 def write_snapshot_disk_usage_matrix(filesystem, suppress_common_prefix=True):


### PR DESCRIPTION
This utility fails to work properly with recent versions of ZFS on Linux, due to a change made in the way that sizes are printed (see: zfsonlinux/zfs@e7fbeb606a).

The main issue is this: previously, sizes under 1 KiB would be printed as a raw number with no unit character following the number; however, since the commit mentioned above, sizes under 1 KiB are now printed with a 'B' suffix to disambiguate that the unit is bytes.

```
Traceback (most recent call last):
  File "./zfs-snapshot-disk-usage-matrix.py", line 126, in <module>
    write_snapshot_disk_usage_matrix(arguments['<filesystem>'])
  File "./zfs-snapshot-disk-usage-matrix.py", line 118, in write_snapshot_disk_usage_matrix
    this_line.append(size_in_bytes(space_used))
  File "./zfs-snapshot-disk-usage-matrix.py", line 100, in size_in_bytes
    return int(size)
ValueError: invalid literal for int() with base 10: '0B'
```

This trivial pull request adds parsing logic to handle the 'B' suffix, while still retaining support for suffixless size values produced by older versions of ZFS on Linux or by other ZFS implementations.