### PR TITLE
Remove docopt

### DIFF
--- a/zfs-snapshot-disk-usage-matrix.py
+++ b/zfs-snapshot-disk-usage-matrix.py
@@ -113,7 +113,7 @@ if __name__ == '__main__':
     arguments=docopt(__doc__)
     write_snapshot_disk_usage_matrix(arguments['<filesystem>'])
 
-# Useful for     
+# Useful for
 # snapshots_in_creation_order('local-fast-tank-machine0/Virtual-Machines/VirtualBox/vpn-linux-u14')
 # space_between_snapshots('local-fast-tank-machine0/Virtual-Machines/VirtualBox/vpn-linux-u14',
 #                         'zfs-auto-snap_monthly-2015-03-18-2345',

--- a/zfs-snapshot-disk-usage-matrix.py
+++ b/zfs-snapshot-disk-usage-matrix.py
@@ -35,8 +35,6 @@ Example:
 
 """
 
-from docopt import docopt
-
 import subprocess, sys, fcntl
 from os.path import commonprefix
 
@@ -110,8 +108,7 @@ def write_snapshot_disk_usage_matrix(filesystem, suppress_common_prefix=True):
         print_csv([this_line])
 
 if __name__ == '__main__':
-    arguments=docopt(__doc__)
-    write_snapshot_disk_usage_matrix(arguments['<filesystem>'])
+    write_snapshot_disk_usage_matrix(sys.argv[1])
 
 # Useful for
 # snapshots_in_creation_order('local-fast-tank-machine0/Virtual-Machines/VirtualBox/vpn-linux-u14')


### PR DESCRIPTION
I'd (also) like to suggest to remove `docopt` as a dependency. It has not been touched in fife years. Besides, without it, the script runs with Python's standard library only making it self-contained. The suggested solution is not elegant or ideal, but robust enough for this use-case.